### PR TITLE
Normalize default uri into a config option

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,19 @@ Or to a NetworkX ``MultiDiGraph``::
 
 See real examples in an `IPython Notebook`_.
 
+Configuration
+=============
+
+To change the behaviour of the cypher magic function, you can configure it::
+
+    %config CypherMagic
+
+    ... list of options
+
+    %config CypherMagic.some_option = new_value
+
+
+
 Contents
 ========
 

--- a/src/cypher/magic.py
+++ b/src/cypher/magic.py
@@ -56,6 +56,9 @@ class CypherMagic(Magics, Configurable):
     feedback = Bool(defaults.feedback, config=True, help="""
         Print number of rows affected
     """)
+    uri = Unicode(defaults.uri, config=True, help="""
+        Default database URL if none is defined inline
+    """)
 
     def __init__(self, shell):
         Configurable.__init__(self, config=shell.config)

--- a/src/cypher/parse.py
+++ b/src/cypher/parse.py
@@ -1,12 +1,9 @@
 import os
 
-from cypher.utils import DEFAULT_URI
-
-
 def parse(cell, config):
     uri = (os.environ.get("NEO4J_URI")
            or os.environ.get("NEO4J_URL")
-           or DEFAULT_URI)
+           or config.uri)
     uri_as = ""
     parts = [part.strip() for part in cell.split(None, 1)]
     if not parts:

--- a/src/cypher/run.py
+++ b/src/cypher/run.py
@@ -25,7 +25,7 @@ except ImportError:
 from cypher.column_guesser import ColumnGuesserMixin
 from cypher.connection import Connection
 from cypher.utils import (
-    DefaultConfigurable, DEFAULT_URI, DEFAULT_CONFIGURABLE, StringIO,
+    DefaultConfigurable, DEFAULT_CONFIGURABLE, StringIO,
     string_types
 )
 
@@ -489,7 +489,7 @@ def run(query, params=None, config=None, conn=None, **kwargs):
     if params is None:
         params = {}
     if conn is None:
-        conn = Connection.get(DEFAULT_URI)
+        conn = Connection.get(DEFAULT_CONFIGURABLE["uri"])
     elif isinstance(conn, string_types):
         conn = Connection.get(conn)
     if config is None:

--- a/src/cypher/utils.py
+++ b/src/cypher/utils.py
@@ -17,7 +17,6 @@ else:
     text_type = str
     string_types = (str, )
 
-DEFAULT_URI = 'http://localhost:7474/db/data/'
 DEFAULT_CONFIGURABLE = {
     "auto_limit": 0,
     "style": 'DEFAULT',
@@ -29,6 +28,7 @@ DEFAULT_CONFIGURABLE = {
     "auto_networkx": False,
     "rest": False,
     "feedback": True,
+    "uri": 'http://localhost:7474/db/data/',
 }
 
 DefaultConfigurable = namedtuple(


### PR DESCRIPTION
This way, it can be changed more easily. Usually, you run multiple queries against a single server, so it is annoying to always repeat the url.