### PR TITLE
try importing from traitlets, if not available default to old IPython imports

### DIFF
--- a/src/cypher/magic.py
+++ b/src/cypher/magic.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 import re
+
 from IPython.core.magic import (Magics, magics_class, cell_magic, line_magic,
                                 needs_local_scope)
-from IPython.config.configurable import Configurable
-from IPython.utils.traitlets import Bool, Int, Unicode
 try:
     from pandas.core.frame import DataFrame, Series
 except ImportError:
     DataFrame = None
     Series = None
+try:
+    from traitlets import Bool, Int, Unicode
+    from traitlets.config.configurable import Configurable
+except ImportError:
+    from IPython.config.configurable import Configurable
+    from IPython.utils.traitlets import Bool, Int, Unicode
 
 from neo4jrestclient.exceptions import StatusException
 


### PR DESCRIPTION
This pull updates the import statements to try to use ``traitlets`` instead of the ``IPython.utils`` and ``traitlets.config`` instead of ``IPython.config``. In the case of an earlier version of ``IPython``, like ``3.0.0``, the import falls back on the old ``IPython`` modules. 