### PR TITLE
Fix aliases

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,13 @@
 News
 ====
 
+0.2.6
+-----
+
+*Release date: 10-Jan-2018*
+
+* Fix issue with handling of connections aliases.
+
 0.2.5
 -----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'IPython Cypher'
-copyright = u'2015, Javier de la Rosa'
+copyright = u'2018, Javier de la Rosa'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -32,6 +32,9 @@
     CypherMagic.feedback=<Bool>
         Current: True
         Print number of rows affected
+    CypherMagic.uri=<Unicode>
+        Current: u'http://localhost:7474/db/data'
+        Default database URL if none is defined inline
     CypherMagic.rest=<Bool>
         Current: False
         Return full REST representations of objects inside the result sets

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ This work is inspired by Catherine Devlin's `ipython-sql`_.
 
 Releases
 ========
-The latest release of ``ipython-cypher`` is **0.2.5**.
+The latest release of ``ipython-cypher`` is **0.2.6**.
 
 
 Requirements
@@ -29,8 +29,8 @@ Dependencies
 ============
 - neo4jrestclient 2.0
 
-Depending on your needs, you might want to Pandas, NetworkX and/or matplotlib in order for
-``ipython-cypher`` to produce adapted ouputs from Cypher queries. The
+Depending on your needs, you might want to install Pandas, NetworkX and/or matplotlib in order for
+``ipython-cypher`` to produce adapted outputs from Cypher queries. The
 minimum versions supported are detailed below.
 
 - Pandas 0.15

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -42,9 +42,9 @@ better::
     %%cypher https://long.host.ec2.machin.com:7474/db/data as test1
     match (n) return n limit 1
 
-Once is set, can be used as usual::
+Once is set, can be used by preceding the alias with the dollar sign::
 
-    %%cypher test1
+    %%cypher $test1
     match (n) return n limit 1
 
 In order to change the default connection string, the environment variables
@@ -131,6 +131,8 @@ IPython.
     Automatically limit the number of rows displayed (full result set is still stored, default: ``0``).
 - ``feedback (<bool>)``.
     Print number of rows affected (default: ``True``).
+- ``uri (<unicode>)``.
+    Default database URL if none is defined inline (default: ``http://localhost:7474/db/data/``).
 - ``rest (<bool>)``.
     Return full REST representations of objects inside the result sets (default: ``False``).
 - ``short_errors (<bool>)``.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
 
 
-version = '0.2.5'
+version = '0.2.6'
 
 install_requires = [
     'neo4jrestclient>=2.1.0',

--- a/src/cypher/connection.py
+++ b/src/cypher/connection.py
@@ -24,7 +24,7 @@ class Connection(object):
                 gdb = GraphDatabase(self.connections[connect_str])
             else:
                 gdb = GraphDatabase(connect_str)
-                alias = connect_str
+                alias = alias or connect_str
         except:
             print(self.tell_format())
             raise

--- a/src/cypher/connection.py
+++ b/src/cypher/connection.py
@@ -35,7 +35,7 @@ class Connection(object):
         Connection.current = self
 
     @classmethod
-    def get(cls, descriptor):
+    def get(cls, descriptor, alias=None):
         if isinstance(descriptor, Connection):
             cls.current = descriptor
         elif descriptor:
@@ -44,7 +44,7 @@ class Connection(object):
             if conn:
                 cls.current = conn
             else:
-                cls.current = Connection(descriptor)
+                cls.current = Connection(descriptor, alias)
         if cls.current:
             return cls.current
         else:

--- a/src/cypher/magic.py
+++ b/src/cypher/magic.py
@@ -105,7 +105,7 @@ class CypherMagic(Magics, Configurable):
         user_ns = self.shell.user_ns
         user_ns.update(local_ns)
         parsed = parse("""{0}\n{1}""".format(line, cell), self)
-        conn = Connection.get(parsed['as'] or parsed['uri'])
+        conn = Connection.get(parsed['as'] or parsed['uri'], parsed['as'])
         first_word = parsed['cypher'].split(None, 1)[:1]
         if first_word and first_word[0].lower() == 'persist':
             return self._persist_dataframe(parsed['cypher'], conn, user_ns)

--- a/src/cypher/parse.py
+++ b/src/cypher/parse.py
@@ -22,7 +22,8 @@ def parse(cell, config):
         else:
             query = ''
     elif '$' in parts[0]:
-        uri_as, query = parts
+        uri_as = parts[0][1:]
+        query = parts[1]
     else:
         query = cell
     return {'uri': uri.strip(),

--- a/src/cypher/parse.py
+++ b/src/cypher/parse.py
@@ -7,15 +7,22 @@ def parse(cell, config):
     uri_as = ""
     parts = [part.strip() for part in cell.split(None, 1)]
     if not parts:
-        return {'uri': uri, 'cypher': ''}
-    elif ' as ' in parts[0]:
-        uri, uri_as = parts[0].split(' as ')
-    elif '@' in parts[0] or '://' in parts[0]:
+        return {'uri': uri, 'as': uri_as, 'cypher': ''}
+    if '@' in parts[0] or '://' in parts[0]:
         uri = parts[0]
         if len(parts) > 1:
-            query = parts[1]
+            if parts[1].startswith('as '):
+                uri_as_query = parts[1].split('as', 1)[-1].split(None, 1)
+                if len(uri_as_query) == 2:
+                    uri_as, query = uri_as_query
+                else:
+                    uri_as, query = uri_as_query[0], ''
+            else:
+                query = parts[1]
         else:
             query = ''
+    elif '$' in parts[0]:
+        uri_as, query = parts
     else:
         query = cell
     return {'uri': uri.strip(),


### PR DESCRIPTION
Now, after creating a custom alias, it should possible to refer to it by preceding it with the dollar sign.
```
%cypher http://localhost:7474/db/data as local match ...
```
And then
```
%cypher $local match ...
```